### PR TITLE
Add support for mapping is_staff, is_superuser and groups from RADIUS Reply

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,3 +207,18 @@ RADIUS attribute types 1-39 are supported. See the [Radius Types][types]
 IANA page for details.
 
 [types]: http://www.iana.org/assignments/radius-types/radius-types.xhtml
+
+Group Mapping
+---------------------
+
+The authentication backend allows you to map RADIUS Attribute 25 "Class" 
+(See [Radius Types][types]) in the RADIUS Server Reply to the User's 
+is_staff and is_superuser properties and to the groups the User belongs to.
+
+For each role (is_staff and is_superuser) and group mapping one RAIDUS Attribute 
+25 "Class" AVP has to be returned by the RADIUS Server.
+
+The syntax allows the following mappings:
+* `role=staff` (sets the is_staff=True in the User object)
+* `role=superuser` (sets is_superuser=True for the User object)
+* `group=Group1` (add the User object to `Group1`)

--- a/README.md
+++ b/README.md
@@ -219,6 +219,6 @@ For each role (is_staff and is_superuser) and group mapping one RAIDUS Attribute
 25 "Class" AVP has to be returned by the RADIUS Server.
 
 The syntax allows the following mappings:
-* `role=staff` (sets the is_staff=True in the User object)
+* `role=staff` (sets is_staff=True in the User object)
 * `role=superuser` (sets is_superuser=True for the User object)
 * `group=Group1` (add the User object to `Group1`)


### PR DESCRIPTION
This patch adds the ability to map is_staff, is_superuser and groups from RADIUS Attribute 25 "Class" from the RADIUS Server reply.

The syntax allows the following mappings:
* `role=staff` (sets is_staff=True in the User object)
* `role=superuser` (sets is_superuser=True for the User object)
* `group=Group1` (add the User object to `Group1`)