### PR TITLE
Fix bytestring user creation issue; add support for roles/groups assignment from RADIUS attribute "Class"

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ settings.py for the values returned by the RADIUS server in the Attribute 25
 
 ```python
 RADIUS_CLASS_APP_PREFIX = 'someprojectname'
+```
 
 This will make the app look for `someprojectnamerole=` and `someprojectnamegroup=`
 when parsing through the Attribute 25 "Class" AVP and ignore other returned values.

--- a/README.md
+++ b/README.md
@@ -207,3 +207,18 @@ RADIUS attribute types 1-39 are supported. See the [Radius Types][types]
 IANA page for details.
 
 [types]: http://www.iana.org/assignments/radius-types/radius-types.xhtml
+
+Group Mapping
+---------------------
+
+The authentication backend allows you to map RADIUS Attribute 25 "Class" 
+(See [Radius Types][types]) in the RADIUS Server Reply to the User's 
+is_staff and is_superuser properties and to the groups the User belongs to.
+
+For each role (is_staff and is_superuser) and group mapping one RAIDUS Attribute 
+25 "Class" AVP has to be returned by the RADIUS Server.
+
+The syntax allows the following mappings:
+* `role=staff` (sets the is_staff=True in the User object)
+* `role=superuser` (sets is_superuser=True for the User object)
+* `group=Group1` (add the User object to `Group1`)

--- a/README.md
+++ b/README.md
@@ -219,6 +219,6 @@ For each role (is_staff and is_superuser) and group mapping one RAIDUS Attribute
 25 "Class" AVP has to be returned by the RADIUS Server.
 
 The syntax allows the following mappings:
-* `role=staff` (sets the is_staff=True in the User object)
+* `role=staff` (sets is_staff=True in the User object)
 * `role=superuser` (sets is_superuser=True for the User object)
 * `group=Group1` (add the User object to `Group1`)

--- a/README.md
+++ b/README.md
@@ -222,3 +222,14 @@ The syntax allows the following mappings:
 * `role=staff` (sets is_staff=True in the User object)
 * `role=superuser` (sets is_superuser=True for the User object)
 * `group=Group1` (add the User object to `Group1`)
+
+To avoid namespace clashes in the RADIUS Attribute 25 values that may be
+used by other applications, a prefix can be configured in the Django project's
+settings.py for the values returned by the RADIUS server in the Attribute 25
+"Class" AVP:
+
+```python
+RADIUS_CLASS_APP_PREFIX = 'someprojectname'
+
+This will make the app look for `someprojectnamerole=` and `someprojectnamegroup=`
+when parsing through the Attribute 25 "Class" AVP and ignore other returned values.

--- a/radiusauth/backends/radius.py
+++ b/radiusauth/backends/radius.py
@@ -201,11 +201,6 @@ class RADIUSBackend(object):
         Check credentials against RADIUS server and return a User object or
         None.
         """
-        if isinstance(username, basestring):
-            username = username.encode('utf-8')
-
-        if isinstance(password, basestring):
-            password = password.encode('utf-8')
 
         server = self._get_server_from_settings()
         result = self._radius_auth(server, username, password)
@@ -268,11 +263,6 @@ class RADIUSRealmBackend(RADIUSBackend):
         skip this backend and try the next one (as a TypeError will be raised
         and caught).
         """
-        if isinstance(username, basestring):
-            username = username.encode('utf-8')
-
-        if isinstance(password, basestring):
-            password = password.encode('utf-8')
 
         server = self.get_server(realm)
 

--- a/radiusauth/backends/radius.py
+++ b/radiusauth/backends/radius.py
@@ -144,13 +144,16 @@ class RADIUSBackend(object):
         is_staff = False
         is_superuser = False
         
+        app_class_prefix = getattr(settings, 'RADIUS_CLASS_APP_PREFIX', '')
+        group_class_prefix = app_class_prefix + "group="
+        role_class_prefix = app_class_prefix + "role="
         
         for cl in reply['Class']:
             cl = cl.decode("utf-8")
-            if cl.lower().find("group=") == 0:
-                groups.append(cl[6:])
-            elif cl.lower().find("role=") == 0:
-                role = cl[5:]
+            if cl.lower().find(group_class_prefix) == 0:
+                groups.append(cl[len(group_class_prefix):])
+            elif cl.lower().find(role_class_prefix) == 0:
+                role = cl[len(role_class_prefix):]
                 if role == "staff":
                     is_staff = True
                 elif role == "superuser":


### PR DESCRIPTION
Building on Michael Langerreiter's changes to allow using RADIUS AVP 25 "Class" to set groups and roles, this also has, I believe, the fix to the issue mentioned at https://github.com/robgolding/django-radius/issues/18.