### PR TITLE
Don't use pyrad 2.2 due to broken version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,5 +19,5 @@ setup(
     ],
     zip_safe=False,
     packages=find_packages(),
-    install_requires=['pyrad >= 1.2', 'future==0.16.0'],
+    install_requires=['pyrad >= 1.2, != 2.2', 'future==0.16.0'],
 )


### PR DESCRIPTION
pyrad 2.2. errors out during the authentication process, this modifies the install requires to avoid the broken version

See issue on pyrad for more details of the issue
https://github.com/pyradius/pyrad/issues/121