### PR TITLE
Allow use of remote user roles (staff / superuser) to be configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ RADIUS_PORT = 1812
 RADIUS_SECRET = 'S3kr3T'
 ```
 
+You may optionally accept whether the user is a staff or superuser from the
+remote radius server with the following option. If not set, it will default
+to `True`, as django-radius has functioned in earlier versions.
+
+```python
+RADIUS_REMOTE_ROLES = True
+```
+
 When a user is successfully authenticated via the RADIUS backend, a `User`
 object is created in Django's built-in auth application with the same username.
 This user's password is set to the password which they logged into the RADIUS

--- a/radiusauth/backends/radius.py
+++ b/radiusauth/backends/radius.py
@@ -182,8 +182,14 @@ class RADIUSBackend(object):
         except User.DoesNotExist:
             user = User(username=username)
 
-        user.is_staff = is_staff
-        user.is_superuser = is_superuser
+        # if RADIUS_REMOTE_ROLES is not set, configure it to the default value
+        # of versions <= 1.4.0
+        if not hasattr(settings, "RADIUS_REMOTE_ROLES"):
+            settings.RADIUS_REMOTE_ROLES = True
+
+        if settings.RADIUS_REMOTE_ROLES:
+            user.is_staff = is_staff
+            user.is_superuser = is_superuser
         if password is not None:
             user.set_password(password)
         

--- a/setup.py
+++ b/setup.py
@@ -19,5 +19,5 @@ setup(
     ],
     zip_safe=False,
     packages=find_packages(),
-    install_requires=['pyrad >= 1.2', 'future==0.16.0'],
+    install_requires=['pyrad >= 1.2,!=2.2', 'future==0.16.0'],
 )


### PR DESCRIPTION
In large enterprises, it is common for RADIUS infrastructure to function solely as authentication and then for applications to handle their own role management. While not necessarily ideal, high-security applications may require more control over management of application users.

This pull request modifies django-radius to allow the administrator to configure via the Django Settings whether the roles (`is_staff` and `is_superuser`) will be set based on what's returned by the remote server. 