### PR TITLE
Handle bogus non unicode data on IETF:Class-attributes

### DIFF
--- a/radiusauth/__init__.py
+++ b/radiusauth/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '1.3.3'
+VERSION = '1.4.0'

--- a/radiusauth/backends/radius.py
+++ b/radiusauth/backends/radius.py
@@ -149,17 +149,20 @@ class RADIUSBackend(object):
         role_class_prefix = app_class_prefix + "role="
         
         for cl in reply['Class']:
-            cl = cl.decode("utf-8")
-            if cl.lower().find(group_class_prefix) == 0:
-                groups.append(cl[len(group_class_prefix):])
-            elif cl.lower().find(role_class_prefix) == 0:
-                role = cl[len(role_class_prefix):]
-                if role == "staff":
-                    is_staff = True
-                elif role == "superuser":
-                    is_superuser = True
-                else:
-                    logging.warning("RADIUS Attribute Class contains unknown role '%s'. Only roles 'staff' and 'superuser' are allowed" % cl)
+            try:
+                cl = cl.decode("utf-8")
+                if cl.lower().find(group_class_prefix) == 0:
+                    groups.append(cl[len(group_class_prefix):])
+                elif cl.lower().find(role_class_prefix) == 0:
+                    role = cl[len(role_class_prefix):]
+                    if role == "staff":
+                        is_staff = True
+                    elif role == "superuser":
+                        is_superuser = True
+                    else:
+                        logging.warning("RADIUS Attribute Class contains unknown role '%s'. Only roles 'staff' and 'superuser' are allowed" % cl)
+            except UnicodeDecodeError:
+                pass
         return groups, is_staff, is_superuser
 
     def _radius_auth(self, server, username, password):


### PR DESCRIPTION
Some RADIUS-servers like Aruba Clearpass are inserting bogus non unicode data after the configured attributes. The configured attributes are handled correctly but trying to decode the bogus data crashes the process. This PR adds a simple try except clause to handle this issue.