### PR TITLE
Made "su_staff" Class Attribute for role possible to set both is_superuser and is_staff to true in one step. Also fixes #23.

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ For each role (is_staff and is_superuser) and group mapping one RAIDUS Attribute
 The syntax allows the following mappings:
 * `role=staff` (sets is_staff=True in the User object)
 * `role=superuser` (sets is_superuser=True for the User object)
+* `role=su-staff` (sets both is_superuser and is_staff = True for the User object)
 * `group=Group1` (add the User object to `Group1`)
 
 To avoid namespace clashes in the RADIUS Attribute 25 values that may be

--- a/radiusauth/backends/radius.py
+++ b/radiusauth/backends/radius.py
@@ -155,6 +155,11 @@ class RADIUSBackend(object):
                     is_staff = True
                 elif role == "superuser":
                     is_superuser = True
+                # Passing "su-staff" through the Class attribute from the RADIUS server
+                # will set both staff and superuser to true for the user.
+                elif role == "su-staff":
+                    is_staff = True
+                    is_superuser = True
                 else:
                     logging.warning("RADIUS Attribute Class contains unknown role '%s'. Only roles 'staff' and 'superuser' are allowed" % cl)
         return groups, is_staff, is_superuser

--- a/radiusauth/backends/radius.py
+++ b/radiusauth/backends/radius.py
@@ -146,23 +146,27 @@ class RADIUSBackend(object):
         role_class_prefix = app_class_prefix + "role="
 
         for cl in reply['Class']:
-            cl = cl.decode("utf-8")
-            if cl.lower().find(group_class_prefix) == 0:
-                groups.append(cl[len(group_class_prefix):])
-            elif cl.lower().find(role_class_prefix) == 0:
-                role = cl[len(role_class_prefix):]
-                if role == "staff":
-                    is_staff = True
-                elif role == "superuser":
-                    is_superuser = True
-                # Passing "su-staff" through the Class attribute from the RADIUS server
-                # will set both staff and superuser to true for the user.
-                elif role == "su-staff":
-                    is_staff = True
-                    is_superuser = True
-                else:
-                    logging.warning("RADIUS Attribute Class contains unknown role '%s'. Only roles 'staff', "
-                                    "'su-staff' and 'superuser' are allowed" % cl)
+            try:
+                cl = cl.decode("utf-8")
+                if cl.lower().find(group_class_prefix) == 0:
+                    groups.append(cl[len(group_class_prefix):])
+                elif cl.lower().find(role_class_prefix) == 0:
+                    role = cl[len(role_class_prefix):]
+                    if role == "staff":
+                        is_staff = True
+                    elif role == "superuser":
+                        is_superuser = True
+                    # Passing "su-staff" through the Class attribute from the RADIUS server
+                    # will set both staff and superuser to true for the user.
+                    elif role == "su-staff":
+                        is_staff = True
+                        is_superuser = True
+                    else:
+                        logging.warning("RADIUS Attribute Class contains unknown role '%s'. Only roles 'staff', "
+                                        "'su-staff' and 'superuser' are allowed" % cl)
+            except UnicodeDecodeError:
+                logging.warning("RADIUS Attribute Class contains non-unicode value '%s'. Only unicode values are "
+                                "supported" % cl)
         return groups, is_staff, is_superuser
 
     def _radius_auth(self, server, username, password):

--- a/radiusauth/backends/radius.py
+++ b/radiusauth/backends/radius.py
@@ -161,7 +161,8 @@ class RADIUSBackend(object):
                     is_staff = True
                     is_superuser = True
                 else:
-                    logging.warning("RADIUS Attribute Class contains unknown role '%s'. Only roles 'staff' and 'superuser' are allowed" % cl)
+                    logging.warning("RADIUS Attribute Class contains unknown role '%s'. Only roles 'staff', "
+                                    "'su-staff' and 'superuser' are allowed" % cl)
         return groups, is_staff, is_superuser
 
     def _radius_auth(self, server, username, password):


### PR DESCRIPTION
* Added 'su-staff' as a valid Class Attribute coming from RADIUS. This will set both is_staff and is_superuser to True in one action.
* Added relevant call to README to outline changes as documentation.

I needed some mechanism to set both is_staff and is_superuser to True for a user object in one action. 