### PR TITLE
RADIUS_IMPORT_GROUPS setting added

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ For each role (is_staff and is_superuser) and group mapping one RAIDUS Attribute
 The syntax allows the following mappings:
 * `role=staff` (sets is_staff=True in the User object)
 * `role=superuser` (sets is_superuser=True for the User object)
+* `role=su-staff` (sets both is_superuser and is_staff = True for the User object)
 * `group=Group1` (add the User object to `Group1`)
 
 To avoid namespace clashes in the RADIUS Attribute 25 values that may be

--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ to `True`, as django-radius has functioned in earlier versions.
 RADIUS_REMOTE_ROLES = True
 ```
 
+The default behavior is for django-radius to bring groups in from RADIUS 
+when a user is authenticated. You may overwrite this behavior by setting the 
+following in settings.py of your Django project:
+
+```python
+RADIUS_IMPORT_GROUPS = False
+```
+This will still import the is_staff, is_superuser flags from RADIUS according 
+to the role assignment but ignore any group assignments, putting django
+in charge of group to user assignment(s).
+
 When a user is successfully authenticated via the RADIUS backend, a `User`
 object is created in Django's built-in auth application with the same username.
 This user's password is set to the password which they logged into the RADIUS

--- a/radiusauth/backends/radius.py
+++ b/radiusauth/backends/radius.py
@@ -155,6 +155,11 @@ class RADIUSBackend(object):
                     is_staff = True
                 elif role == "superuser":
                     is_superuser = True
+                # Passing "su-staff" through the Class attribute from the RADIUS server
+                # will set both staff and superuser to true for the user.
+                elif role == "su-staff":
+                    is_staff = True
+                    is_superuser = True
                 else:
                     logging.warning("RADIUS Attribute Class contains unknown role '%s'. Only roles 'staff' and 'superuser' are allowed" % cl)
         return groups, is_staff, is_superuser

--- a/radiusauth/backends/radius.py
+++ b/radiusauth/backends/radius.py
@@ -201,7 +201,17 @@ class RADIUSBackend(object):
             user.set_password(password)
 
         user.save()
-        user.groups.set(groups)
+
+        # If RADIUS_IMPORT_GROUPS is not set, configure it to default value False
+        # False means that a user import from RADIUS to Django will NOT overwrite the group
+        # assignment of the user.
+        # The default is TRUE to mimic django-radius's current behavior pre-PR.
+        if not hasattr(settings, "RADIUS_IMPORT_GROUPS"):
+            settings.RADIUS_IMPORT_GROUPS = True
+
+        if settings.RADIUS_IMPORT_GROUPS:
+            user.groups.set(groups)
+
         return user
 
     def get_user_groups(self, group_names):

--- a/radiusauth/backends/radius.py
+++ b/radiusauth/backends/radius.py
@@ -146,23 +146,27 @@ class RADIUSBackend(object):
         role_class_prefix = app_class_prefix + "role="
 
         for cl in reply['Class']:
-            cl = cl.decode("utf-8")
-            if cl.lower().find(group_class_prefix) == 0:
-                groups.append(cl[len(group_class_prefix):])
-            elif cl.lower().find(role_class_prefix) == 0:
-                role = cl[len(role_class_prefix):]
-                if role == "staff":
-                    is_staff = True
-                elif role == "superuser":
-                    is_superuser = True
-                # Passing "su-staff" through the Class attribute from the RADIUS server
-                # will set both staff and superuser to true for the user.
-                elif role == "su-staff":
-                    is_staff = True
-                    is_superuser = True
-                else:
-                    logging.warning("RADIUS Attribute Class contains unknown role '%s'. Only roles 'staff', "
-                                    "'su-staff' and 'superuser' are allowed" % cl)
+            try:
+                cl = cl.decode("utf-8")
+                if cl.lower().find(group_class_prefix) == 0:
+                    groups.append(cl[len(group_class_prefix):])
+                elif cl.lower().find(role_class_prefix) == 0:
+                    role = cl[len(role_class_prefix):]
+                    if role == "staff":
+                        is_staff = True
+                    elif role == "superuser":
+                        is_superuser = True
+                    # Passing "su-staff" through the Class attribute from the RADIUS server
+                    # will set both staff and superuser to true for the user.
+                    elif role == "su-staff":
+                        is_staff = True
+                        is_superuser = True
+                    else:
+                        logging.warning("RADIUS Attribute Class contains unknown role '%s'. Only roles 'staff', "
+                                        "'su-staff' and 'superuser' are allowed" % cl)
+            except UnicodeDecodeError:
+                logging.warning("RADIUS Attribute Class contains non-unicode value '%s'. Only unicode values are "
+                                "supported" % cl)
         return groups, is_staff, is_superuser
 
     def _radius_auth(self, server, username, password):

--- a/radiusauth/backends/radius.py
+++ b/radiusauth/backends/radius.py
@@ -161,7 +161,8 @@ class RADIUSBackend(object):
                     is_staff = True
                     is_superuser = True
                 else:
-                    logging.warning("RADIUS Attribute Class contains unknown role '%s'. Only roles 'staff' and 'superuser' are allowed" % cl)
+                    logging.warning("RADIUS Attribute Class contains unknown role '%s'. Only roles 'staff', "
+                                    "'su-staff' and 'superuser' are allowed" % cl)
         return groups, is_staff, is_superuser
 
     def _radius_auth(self, server, username, password):


### PR DESCRIPTION
I needed a way to import is_staff and is_superuser from RADIUS and NOT overwrite the group assignment from RADIUS. I wanted Django to be in charge of group assignments.
The default of this setting is TRUE, to mimic current django-radius behavior. A quite "RADIUS_IMPORT_GROUPS" setting to False in django will prevent the RADIUS auth mechanism from assigning groups to the user as they're imported.