### PR TITLE
su-staff setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ For each role (is_staff and is_superuser) and group mapping one RAIDUS Attribute
 The syntax allows the following mappings:
 * `role=staff` (sets is_staff=True in the User object)
 * `role=superuser` (sets is_superuser=True for the User object)
+* `role=su-staff` (sets both is_superuser and is_staff te True for the User object)
 * `group=Group1` (add the User object to `Group1`)
 
 To avoid namespace clashes in the RADIUS Attribute 25 values that may be

--- a/radiusauth/backends/radius.py
+++ b/radiusauth/backends/radius.py
@@ -155,8 +155,12 @@ class RADIUSBackend(object):
                     is_staff = True
                 elif role == "superuser":
                     is_superuser = True
+                elif role == "su-staff":
+                    # su-staff role assignment sets both is_staff and is_superuser to True for the user in one step.
+                    is_staff = True
+                    is_superuser = True
                 else:
-                    logging.warning("RADIUS Attribute Class contains unknown role '%s'. Only roles 'staff' and 'superuser' are allowed" % cl)
+                    logging.warning("RADIUS Attribute Class contains unknown role '%s'. Only roles 'staff', 'superuser' and 'su-staff' are allowed" % cl)
         return groups, is_staff, is_superuser
 
     def _radius_auth(self, server, username, password):


### PR DESCRIPTION
django-radius will now accept a role=su-staff Class 25 attribute from the RADIUS server to set both is_superuser and is_staff to True for the user in one step.

I needed a way for my RADIUS server to send ONE Class attribute only, but set both is_staff and is_superuser to True (for example, a domain admin having full access to the panel).