### PR TITLE
RADIUS_IMPORT_GROUPS setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ to `True`, as django-radius has functioned in earlier versions.
 RADIUS_REMOTE_ROLES = True
 ```
 
+The default behavior is for django-radius to bring groups in from RADIUS 
+when a user is authenticated. You may overwrite this behavior by setting the 
+following in settings.py of your Django project:
+
+```python
+RADIUS_IMPORT_GROUPS = False
+```
+
+This will still import the is_staff, is_superuser flags from RADIUS according 
+to the role assignment but ignore any group assignments, putting django
+in charge of group to user assignment(s).
+
 When a user is successfully authenticated via the RADIUS backend, a `User`
 object is created in Django's built-in auth application with the same username.
 This user's password is set to the password which they logged into the RADIUS

--- a/radiusauth/backends/radius.py
+++ b/radiusauth/backends/radius.py
@@ -191,7 +191,17 @@ class RADIUSBackend(object):
             user.set_password(password)
 
         user.save()
-        user.groups.set(groups)
+
+        # If RADIUS_IMPORT_GROUPS is not set, configure it to default value False.
+        # False means that a user import from RADIUS to Django will NOT overwrite the group
+        # assignment of the user.
+        # The default is TRUE to mimic django-radius's current behavior pre Pull Request.
+        if not hasattr(settings, "RADIUS_IMPORT_GROUPS"):
+            settings.RADIUS_IMPORT_GROUPS = True
+
+        if settings.RADIUS_IMPORT_GROUPS:
+            user.groups.set(groups)
+
         return user
 
     def get_user_groups(self, group_names):


### PR DESCRIPTION
This allows you to implicitly set django to be in charge of group assignments, while still keeping remote_roles setting that will still bring over the is_staff and is_superuser flags from RADIUS.

The default behavior seems to be that django-radius always sets the groups of the user to what is coming over from RADIUS regardless of if you set them or not. I wanted django to be implicitly in charge of group assignments, and ignore what RADIUS sends.